### PR TITLE
remove broken upx command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN git checkout $COMMIT
 WORKDIR /build/KISS-multiplayer/kissmp-server/
 RUN cargo build -j $(( $(nproc) + 1 )) --release
 RUN strip /build/KISS-multiplayer/target/release/kissmp-server
-RUN upx --best --lzma /build/KISS-multiplayer/target/release/kissmp-server
 
 FROM alpine:3.11
 RUN apk add upx

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -10,7 +10,6 @@ WORKDIR KISS-multiplayer
 WORKDIR /build/KISS-multiplayer/kissmp-server/
 RUN cargo build -j $(( $(nproc) + 1 )) --release
 RUN strip /build/KISS-multiplayer/target/release/kissmp-server
-RUN upx --best --lzma /build/KISS-multiplayer/target/release/kissmp-server
 
 FROM alpine:3.11
 RUN apk add upx


### PR DESCRIPTION
First upx command was breaking the docker image, upx was supposed to be ran later in the docker file and not twice. This commit removes the command and the docker image now successfully builds and works.